### PR TITLE
Remove --color-title from .content strong

### DIFF
--- a/src/typography/content.css
+++ b/src/typography/content.css
@@ -114,8 +114,6 @@
   }
 
   strong {
-    color: var(--color-title);
-
     @apply font-medium;
   }
 


### PR DESCRIPTION
Hi! I was working on a project using a17t (which helps a lot!), and when I added `content` on white markdown text with dark background, all **strong** elements turned black according to the `--color-title` variable. Would you consider removing the rule? That way a17t users won't have to override the style manually if they use a text color other than black.